### PR TITLE
feat: add tooltip for quality error description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feat: Emit mouse event signal for selected error feature
 - Feat: New filter to filter quality errors by error attribute value
+- Feat: Add tooltip for quality error description
 
 ## [0.0.3] - 2022-12-15
 

--- a/src/quality_result_gui/quality_errors_tree_model.py
+++ b/src/quality_result_gui/quality_errors_tree_model.py
@@ -193,6 +193,14 @@ class QualityErrorTreeItem:
             return item_data["fi"]
 
         if (
+            role == Qt.ToolTipRole
+            and column == ModelColumn.ERROR_DESCRIPTION
+            and self.item_type == QualityErrorTreeItemType.ERROR
+        ):
+            # lang = locale.get_qgis_locale().split("_")[0]
+            return item_data["fi"]
+
+        if (
             role == Qt.CheckStateRole
             and column == ModelColumn.TYPE_OR_ID
             and self.item_type == QualityErrorTreeItemType.ERROR

--- a/src/quality_result_gui/quality_errors_tree_model.py
+++ b/src/quality_result_gui/quality_errors_tree_model.py
@@ -185,15 +185,7 @@ class QualityErrorTreeItem:
             return QVariant(column_data)
 
         if (
-            role == Qt.DisplayRole
-            and column == ModelColumn.ERROR_DESCRIPTION
-            and self.item_type == QualityErrorTreeItemType.ERROR
-        ):
-            # lang = locale.get_qgis_locale().split("_")[0]
-            return item_data["fi"]
-
-        if (
-            role == Qt.ToolTipRole
+            role in [Qt.DisplayRole, Qt.ToolTipRole]
             and column == ModelColumn.ERROR_DESCRIPTION
             and self.item_type == QualityErrorTreeItemType.ERROR
         ):


### PR DESCRIPTION
Long descriptions are not completely visible in quality error dock.