### PR TITLE
fix: hide empty branches when all errors are processed and filtered out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Hide empty branches from quality error list when user processed errors are hidden and user processes all errors for a feature
+
 ## [0.0.4] - 2022-12-28
 
 - Feat: Emit mouse event signal for selected error feature

--- a/src/quality_result_gui/quality_errors_tree_model.py
+++ b/src/quality_result_gui/quality_errors_tree_model.py
@@ -397,6 +397,11 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
                     quality_error.unique_identifier, checked
                 )
                 self.dataChanged.emit(index, index)
+
+                parent_index = index
+                while parent_index.isValid():
+                    parent_index = parent_index.parent()
+                    self.dataChanged.emit(parent_index, parent_index)
                 return True
 
         return False

--- a/test/quality_result_gui/test_quality_errors_tree_model.py
+++ b/test/quality_result_gui/test_quality_errors_tree_model.py
@@ -668,3 +668,26 @@ def test_refresh_model_does_nothing_if_data_does_not_change(
         _count_quality_error_rows(base_model, base_model.index(0, 0, QModelIndex()))
         == 4
     )
+
+
+def test_no_rows_visible_when_all_user_processed(
+    model: FilterByExtentModel,
+):
+    model.sourceModel().update_filters(
+        {"chimney_point"},
+        {1},
+        {"height_relative"},
+        False,
+    )
+
+    assert _count_quality_error_rows(model, _priority_1_index(model)) == 1
+    assert _count_quality_error_rows(model, _priority_2_index(model)) == 0
+
+    model.setData(
+        _priority_1_feature_type_1_feature_1_error_1_index(model),
+        Qt.Checked,
+        Qt.CheckStateRole,
+    )
+
+    assert _count_quality_error_rows(model, _priority_1_index(model)) == 0
+    assert _count_quality_error_rows(model, _priority_2_index(model)) == 0


### PR DESCRIPTION
Feature and feature type branches should not be visible when user processed filter is turned on and user marks all errors as processed.