### PR TITLE
fix: Do not zoom to error when geometry is null geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Do not zoom to error when geometry is null geometry
+
 ## [1.1.4] - 2023-03-08
 
 - Fix: Show correct error count when errors are filtered

--- a/src/quality_result_gui/quality_error_visualizer.py
+++ b/src/quality_result_gui/quality_error_visualizer.py
@@ -80,7 +80,11 @@ class QualityErrorVisualizer:
         preserve_scale = selection_type == SelectionType.RightClick
 
         # Zoom and flash feature only when row is selected by user
-        if selection_type != SelectionType.Other:
+        # and geometry is not null geometry
+        if (
+            selection_type != SelectionType.Other
+            and quality_error.geometry.isNull() is False
+        ):
             self.zoom_to_geometries_and_flash(
                 [quality_error], preserve_scale=preserve_scale
             )


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

fix: Do not zoom to error when geometry is null geometry

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/quality-result-gui/blob/main/CHANGELOG.md
