### PR TITLE
feat: add ability to display feature type and field aliases for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Feat: Add functionality to display quality error feature type and attribute names from layer aliases.
+
 ## [1.1.5] - 2023-03-29
 
 - Fix: Do not zoom to error when geometry is null geometry

--- a/src/quality_result_gui/layer_mapping.py
+++ b/src/quality_result_gui/layer_mapping.py
@@ -1,0 +1,61 @@
+#  Copyright (C) 2023 National Land Survey of Finland
+#  (https://www.maanmittauslaitos.fi/en).
+#
+#
+#  This file is part of quality-result-gui.
+#
+#  quality-result-gui is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  quality-result-gui is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with quality-result-gui. If not, see <https://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from qgis.core import QgsField, QgsProject, QgsVectorLayer
+
+
+@dataclass
+class LayerMapping:
+    layer_map: Optional[Dict[str, str]]
+
+    def get_layer_alias(self, feature_type: str) -> str:
+        layer = self._get_layer(feature_type)
+        if layer is None:
+            return feature_type
+        return layer.name()
+
+    def get_field_alias(self, feature_type: str, field_name: str) -> str:
+        def predicate(field: QgsField) -> bool:
+            return field.name() == field_name
+
+        layer = self._get_layer(feature_type)
+        if layer is None:
+            return field_name
+        attribute = next(filter(predicate, layer.fields()), None)
+        if attribute is None:
+            return field_name
+        return attribute.displayName()
+
+    def _get_layer(self, feature_type: str) -> Optional[QgsVectorLayer]:
+        if not self.layer_map:
+            return None
+        layer_id = self.layer_map.get(feature_type)
+        if not layer_id:
+            return None
+        return next(
+            (
+                layer
+                for layer in QgsProject.instance().mapLayers().values()
+                if layer.id() == layer_id
+            ),
+            None,
+        )

--- a/src/quality_result_gui/quality_error_manager.py
+++ b/src/quality_result_gui/quality_error_manager.py
@@ -18,7 +18,7 @@
 #  along with quality-result-gui. If not, see <https://www.gnu.org/licenses/>.
 
 
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Dict, Optional, cast
 
 from qgis.gui import QgisInterface
 from qgis.PyQt.QtCore import QObject, pyqtSignal
@@ -27,10 +27,14 @@ from qgis_plugin_tools.tools.i18n import tr
 
 from quality_result_gui import SelectionType
 from quality_result_gui.api.types.quality_error import QualityError
+from quality_result_gui.layer_mapping import LayerMapping
 from quality_result_gui.quality_data_fetcher import (
     CHECK_STATUS_LABELS,
     BackgroundQualityResultsFetcher,
     CheckStatus,
+)
+from quality_result_gui.quality_error_manager_settings import (
+    QualityResultManagerSettings,
 )
 from quality_result_gui.quality_error_visualizer import QualityErrorVisualizer
 from quality_result_gui.quality_errors_filters import (
@@ -177,3 +181,8 @@ class QualityResultManager(QObject):
         filter.filters_changed.connect(self.dock_widget._update_filter_menu_icon_state)
         self.dock_widget.filter_menu.add_filter_menu(filter.menu)
         self._filter_model.add_filter(filter)
+
+    def set_layer_mapping(self, layer_mapping: Dict[str, str]) -> None:
+        QualityResultManagerSettings.get().set_layer_mapping(
+            LayerMapping(layer_map=layer_mapping)
+        )

--- a/src/quality_result_gui/quality_error_manager_settings.py
+++ b/src/quality_result_gui/quality_error_manager_settings.py
@@ -1,0 +1,42 @@
+#  Copyright (C) 2023 National Land Survey of Finland
+#  (https://www.maanmittauslaitos.fi/en).
+#
+#
+#  This file is part of quality-result-gui.
+#
+#  quality-result-gui is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  quality-result-gui is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with quality-result-gui. If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional
+
+from qgis.PyQt.QtCore import QObject
+
+from quality_result_gui.layer_mapping import LayerMapping
+
+
+class QualityResultManagerSettings(QObject):
+    """
+    Singleton for storing common properties.
+    """
+
+    _instance: Optional["QualityResultManagerSettings"] = None
+    layer_mapping: LayerMapping = LayerMapping(layer_map=None)
+
+    @staticmethod
+    def get() -> "QualityResultManagerSettings":
+        if QualityResultManagerSettings._instance is None:
+            QualityResultManagerSettings._instance = QualityResultManagerSettings()
+        return QualityResultManagerSettings._instance
+
+    def set_layer_mapping(self, layer_mapping: LayerMapping) -> None:
+        self.layer_mapping = layer_mapping

--- a/src/quality_result_gui/quality_errors_filters.py
+++ b/src/quality_result_gui/quality_errors_filters.py
@@ -29,6 +29,9 @@ from qgis.PyQt.QtWidgets import QAction, QMenu
 from qgis_plugin_tools.tools.i18n import tr
 
 from quality_result_gui.api.types.quality_error import ERROR_TYPE_LABEL, QualityError
+from quality_result_gui.quality_error_manager_settings import (
+    QualityResultManagerSettings,
+)
 from quality_result_gui.quality_errors_tree_model import QualityErrorTreeItemType
 
 if TYPE_CHECKING:
@@ -383,12 +386,17 @@ class FeatureTypeFilter(AbstractQualityErrorFilter):
             quality_errors (List[&quot;QualityErrorsByPriority&quot;]): _description_
         """
         feature_types_in_errors = {  # Dict[filter_value, filter_label]
-            errors.feature_type: errors.feature_type
+            errors.feature_type: self._get_label_value(errors.feature_type)
             for errors_by_feature_type in quality_errors
             for errors in errors_by_feature_type.errors
         }
 
         self._refresh_filters(feature_types_in_errors)
+
+    def _get_label_value(self, feature_type: str) -> str:
+        return QualityResultManagerSettings.get().layer_mapping.get_layer_alias(
+            feature_type
+        )
 
 
 class AttributeFilter(AbstractQualityErrorFilter):
@@ -418,7 +426,9 @@ class AttributeFilter(AbstractQualityErrorFilter):
         self, quality_errors: List["QualityErrorsByPriority"]
     ) -> None:
         attribute_names_in_errors = {  # Dict[filter_value, filter_label]
-            error.attribute_name: error.attribute_name
+            error.attribute_name: self._get_label_value(
+                error.feature_type, error.attribute_name
+            )
             for errors_by_priority in quality_errors
             for errors_by_feature_type in errors_by_priority.errors
             for errors_by_feature in errors_by_feature_type.errors
@@ -427,3 +437,8 @@ class AttributeFilter(AbstractQualityErrorFilter):
         }
 
         self._refresh_filters(attribute_names_in_errors)
+
+    def _get_label_value(self, feature_type: str, attribute_name: str) -> str:
+        return QualityResultManagerSettings.get().layer_mapping.get_field_alias(
+            feature_type, attribute_name
+        )

--- a/src/quality_result_gui/quality_errors_tree_model.py
+++ b/src/quality_result_gui/quality_errors_tree_model.py
@@ -59,6 +59,9 @@ from quality_result_gui.api.types.quality_error import (
     QualityErrorPriority,
     QualityErrorsByPriority,
 )
+from quality_result_gui.quality_error_manager_settings import (
+    QualityResultManagerSettings,
+)
 
 if TYPE_CHECKING:
     from qgis.core import QgsRectangle
@@ -233,9 +236,11 @@ class QualityErrorTreeItem:
                 column_data = ERROR_PRIORITY_LABEL[QualityErrorPriority(item_data)]
 
             elif self.item_type == QualityErrorTreeItemType.FEATURE_TYPE:
-                column_data = item_data
-                # TODO: how to configurate custom data mapping
-                # column_data = common.FEATURE_TYPE_NAMES[item_data]
+                column_data = (
+                    QualityResultManagerSettings.get().layer_mapping.get_layer_alias(
+                        item_data
+                    )
+                )
 
             elif self.item_type == QualityErrorTreeItemType.FEATURE:
                 column_data = item_data[1][:8]
@@ -446,7 +451,6 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
         return super().flags(index)
 
     def refresh_model(self, quality_errors: List[QualityErrorsByPriority]) -> None:
-
         updated_quality_error_ids = {
             error.unique_identifier
             for errors_by_priority in quality_errors
@@ -571,7 +575,6 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
             )
 
     def _get_index_for_item(self, item: QualityErrorTreeItem) -> QModelIndex:
-
         if item.item_type == QualityErrorTreeItemType.HEADER:
             return QModelIndex()
         else:

--- a/test/integration/test_filters.py
+++ b/test/integration/test_filters.py
@@ -188,7 +188,6 @@ def test_select_and_deselect_all_actions_are_present(
     filter_menu: QualityErrorsTreeFilterMenu,
     is_action_present: Callable[[QMenu, str], bool],
 ):
-
     for action in filter_menu.actions():
         if action.menu() is not None:
             assert is_action_present(
@@ -345,7 +344,6 @@ def test_actions_are_connected_to_correct_implementation_methods_and_filters_are
     expected_feature_attributes: list[str],
     expected_error_types: list[int],
 ):
-
     # Baseline filters for menu
     assert get_checked_menu_items(error_type_menu) == sorted(ERROR_TYPE_LABEL.values())
     assert get_checked_menu_items(feature_type_menu) == error_feature_types
@@ -485,7 +483,6 @@ def test_filters_are_retained_when_data_changes(
     expected_attribute_filter_options_after_revert: list[str],
     request: pytest.FixtureRequest,
 ):
-
     assert get_checked_menu_items(feature_type_menu) == error_feature_types
     assert get_checked_menu_items(attribute_menu) == error_feature_attributes
 
@@ -581,3 +578,27 @@ def test_updating_filter_refreshes_errors_on_tree_view_and_map(
 
     # Test filter button changed
     assert quality_result_manager_with_data.dock_widget.filter_button.isDown() is True
+
+
+def test_filter_menu_label_aliases(
+    filter_menu_with_chimney_point_alias: QualityErrorsTreeFilterMenu,
+    get_submenu_from_menu: Callable[[QMenu, str], Optional[QMenu]],
+):
+    feature_type_menu = get_submenu_from_menu(
+        filter_menu_with_chimney_point_alias, FEATURE_TYPE_FILTER_MENU_LABEL
+    )
+    attribute_type_menu = get_submenu_from_menu(
+        filter_menu_with_chimney_point_alias, ATTRIBUTE_NAME_FILTER_MENU_LABEL
+    )
+    feature_type_menu = get_submenu_from_menu(
+        filter_menu_with_chimney_point_alias, FEATURE_TYPE_FILTER_MENU_LABEL
+    )
+
+    assert feature_type_menu is not None
+    assert attribute_type_menu is not None
+    assert "chimney point alias" in [
+        action.text() for action in feature_type_menu.actions()
+    ]
+    assert "height relative alias" in [
+        action.text() for action in attribute_type_menu.actions()
+    ]

--- a/test/integration/test_tree_view.py
+++ b/test/integration/test_tree_view.py
@@ -317,7 +317,6 @@ def test_model_reset_expands_error_rows_recursively_on_tree_view(
     quality_result_manager_with_data: QualityResultManager,
     quality_errors: List[QualityErrorsByPriority],
 ) -> None:
-
     quality_result_manager_with_data._fetcher.results_received.emit(quality_errors)
 
     errors_index = (
@@ -393,3 +392,14 @@ def test_model_reset_expands_error_rows_recursively_on_tree_view(
         )
         is True
     )
+
+
+def test_quality_error_tree_view_with_layer_aliases(
+    quality_result_manager_with_data_and_layer_mapping: QualityResultManager,
+) -> None:
+    model = (
+        quality_result_manager_with_data_and_layer_mapping.dock_widget.error_tree_view.model()
+    )
+    first_priority_index = model.index(0, 0, QModelIndex())
+    feature_type = first_priority_index.child(1, 0).data()
+    assert feature_type == "chimney point alias"


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Method `set_layer_mapping` provides functionality to define which layer corresponds feature types defined in quality errors. If valid mappings is provided feature type and error attribute names are displayed from aliases defined in layer.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

- [x] Non-breaking change
- [] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/quality-result-gui/blob/main/CHANGELOG.md
