### PR TITLE
chore: update pytest-qgis version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ pytest==6.2.5
 pytest-qt==3.3.0
 pytest-cov==2.12.0
 pytest-mock==3.7.0
-pytest-qgis==1.3.0
+pytest-qgis==1.3.5
 pytest-timeout==1.4.2
 pytest-order==1.0.0
 pytest-dotenv==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ pytest-mock==3.7.0
     # via -r requirements.in
 pytest-order==1.0.0
     # via -r requirements.in
-pytest-qgis==1.3.0
+pytest-qgis==1.3.5
     # via -r requirements.in
 pytest-qt==3.3.0
     # via -r requirements.in


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Update pytest-qgis version to such which works with QGIS 3.30.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/quality-result-gui/blob/main/CHANGELOG.md
