### PR TITLE
fix: include .qm file to release zip generated by workflow

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ quality_result_gui_plugin =
     **/*.json
     **/*.svg
     **/*.ts
+    **/*.qm
 
 [options.entry_points]
 qgis_plugin_dev_tools =


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Change release workflow so that it includes also .qm files and not just .ts files.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/quality-result-gui/blob/main/CHANGELOG.md
