### PR TITLE
fix: invalidate user processed and extent filters on data change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Filter newly inserted quality error rows correctly with user processed and map extent filters
+
 ## [2.0.4] - 2023-10-05
 
 - Fix: Redraw map when an error is selected and errors are not visualized on map

--- a/src/quality_result_gui/quality_error_manager.py
+++ b/src/quality_result_gui/quality_error_manager.py
@@ -105,9 +105,15 @@ class QualityResultManager(QObject):
 
         self._filter_user_processed_model = FilterByShowUserProcessedProxyModel()
         self._filter_user_processed_model.setSourceModel(self._filter_model)
+        self._base_model.filterable_data_changed.connect(
+            self._filter_user_processed_model.invalidateFilter
+        )
 
         self._filter_map_extent_model = FilterByExtentProxyModel()
         self._filter_map_extent_model.setSourceModel(self._filter_user_processed_model)
+        self._base_model.filterable_data_changed.connect(
+            self._filter_map_extent_model.invalidateFilter
+        )
 
         self._styled_model = StyleProxyModel()
         self._styled_model.setSourceModel(self._filter_map_extent_model)


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

User processed and map extent filters were not invalidated when tree model data was changed and new rows did not become visible.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/quality-result-gui/blob/main/CHANGELOG.md
