### PR TITLE
fix: invalidate chained filters correctly when data is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Process modifications in quality error tree correctly when multiple filters are present
+
 ## [2.0.6] - 2024-01-05
 
 - Fix: Show correct results when user processed filter is toggled with map extent filter active

--- a/src/quality_result_gui/quality_error_manager.py
+++ b/src/quality_result_gui/quality_error_manager.py
@@ -107,7 +107,7 @@ class QualityResultManager(QObject):
         # Checkbox for filtering out user processed rows
         self._filter_user_processed_model = FilterByShowUserProcessedProxyModel()
         self._filter_user_processed_model.setSourceModel(self._filter_model)
-        self._base_model.filterable_data_changed.connect(
+        self._filter_model.filter_invalidated.connect(
             self._filter_user_processed_model.invalidateFilter
         )
         self.dock_widget.show_user_processed_errors_check_box.toggled.connect(
@@ -117,7 +117,7 @@ class QualityResultManager(QObject):
         # Checkbox for filtering out rows outside map extent
         self._filter_map_extent_model = FilterByExtentProxyModel()
         self._filter_map_extent_model.setSourceModel(self._filter_user_processed_model)
-        self._base_model.filterable_data_changed.connect(
+        self._filter_user_processed_model.filter_invalidated.connect(
             self._filter_map_extent_model.invalidateFilter
         )
         self.dock_widget.filter_with_map_extent_check_box.toggled.connect(

--- a/src/quality_result_gui/quality_errors_tree_model.py
+++ b/src/quality_result_gui/quality_errors_tree_model.py
@@ -657,9 +657,15 @@ class StyleProxyModel(QIdentityProxyModel):
 
 
 class AbstractFilterProxyModel(QSortFilterProxyModel):
+    filter_invalidated = pyqtSignal()
+
     def __init__(self, parent: Optional[QObject] = None) -> None:
         super().__init__(parent)
         self.setFilterRole(Qt.UserRole)
+
+    def invalidateFilter(self) -> None:  # noqa: N802 (qt override)
+        super().invalidateFilter()
+        self.filter_invalidated.emit()
 
     def filterAcceptsRow(  # noqa: N802 (qt override)
         self, source_row: int, source_parent: QModelIndex


### PR DESCRIPTION
Instead of invalidating all filters at the same moment invalidate them sequentially in correct order.

## Description <!-- markdownlint-disable-line MD041 -->

<!--- Summary of your changes -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/quality-result-gui/blob/main/CHANGELOG.md
