### PR TITLE
Add qt6 and QGIS>=4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Chore: Add qt6 and QGIS 4 support
+
 ## [2.0.9] - 2025-01-29
 
 - Fix: Fix missing localization by including them in setuptools build

--- a/src/quality_result_gui/quality_errors_tree_model.py
+++ b/src/quality_result_gui/quality_errors_tree_model.py
@@ -56,6 +56,7 @@ from quality_result_gui.api.types.quality_error import (
 from quality_result_gui.quality_error_manager_settings import (
     QualityResultManagerSettings,
 )
+from quality_result_gui.utils.qt_utils import NULL
 
 if TYPE_CHECKING:
     from qgis.core import QgsRectangle
@@ -107,7 +108,7 @@ def _get_quality_errors_indexes(
 
     row_count = model.rowCount(index)
     if row_count == 0:
-        data = index.data(Qt.UserRole)
+        data = index.data(Qt.ItemDataRole.UserRole)
         (item_type, _) = cast(ErrorDataType, data)
         if item_type == QualityErrorTreeItemType.ERROR:
             # Index is for quality error row, which has no children
@@ -123,7 +124,7 @@ def _count_quality_error_rows(model: QAbstractItemModel, index: QModelIndex) -> 
     num_rows = 0
     row_count = model.rowCount(index)
     if row_count == 0:
-        data = index.data(Qt.UserRole)
+        data = index.data(Qt.ItemDataRole.UserRole)
         (item_type, _) = cast(ErrorDataType, data)
         if item_type == QualityErrorTreeItemType.ERROR:
             # Index is for quality error row
@@ -200,20 +201,20 @@ class QualityErrorTreeItem:
         return len(self._item_data)
 
     def data(  # noqa: C901, PLR0911, PLR0912
-        self, column_index: int, role: Qt.ItemDataRole = Qt.DisplayRole
+        self, column_index: int, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
     ) -> QVariant:
         if not (column_index >= 0 and column_index < len(self._item_data)):
-            return QVariant()
+            return NULL
 
         item_data = self._item_data[column_index]
-        column_data = QVariant()
+        column_data = NULL
 
         column = ModelColumn(column_index)
 
         if self.item_type == QualityErrorTreeItemType.HEADER:
-            return QVariant()
+            return NULL
 
-        if role == Qt.UserRole and column in [
+        if role == Qt.ItemDataRole.UserRole and column in [
             ModelColumn.TYPE_OR_ID,
             ModelColumn.ERROR_DESCRIPTION,
         ]:
@@ -224,7 +225,7 @@ class QualityErrorTreeItem:
             )
             return (self.item_type, self._item_data[index])
 
-        if role == Qt.DisplayRole and column == ModelColumn.TYPE_OR_ID:
+        if role == Qt.ItemDataRole.DisplayRole and column == ModelColumn.TYPE_OR_ID:
             if self.item_type == QualityErrorTreeItemType.PRIORITY:
                 column_data = ERROR_PRIORITY_LABEL[QualityErrorPriority(item_data)]()
 
@@ -244,14 +245,14 @@ class QualityErrorTreeItem:
             return QVariant(column_data)
 
         if (
-            role == Qt.DisplayRole
+            role == Qt.ItemDataRole.DisplayRole
             and column == ModelColumn.ERROR_DESCRIPTION
             and self.item_type == QualityErrorTreeItemType.ERROR
         ):
             return item_data["error_description"]
 
         if (
-            role == Qt.ToolTipRole
+            role == Qt.ItemDataRole.ToolTipRole
             and column == ModelColumn.ERROR_DESCRIPTION
             and self.item_type == QualityErrorTreeItemType.ERROR
         ):
@@ -261,17 +262,17 @@ class QualityErrorTreeItem:
             return f"<p>{item_data['error_description']}</p><p>{extra_info}</p>"
 
         if (
-            role == Qt.CheckStateRole
+            role == Qt.ItemDataRole.CheckStateRole
             and column == ModelColumn.TYPE_OR_ID
             and self.item_type == QualityErrorTreeItemType.ERROR
         ):
             quality_error = cast(QualityError, item_data)
             if quality_error.is_user_processed is True:
-                return QVariant(Qt.Checked)
+                return QVariant(Qt.CheckState.Checked)
             else:
-                return QVariant(Qt.Unchecked)
+                return QVariant(Qt.CheckState.Unchecked)
 
-        return QVariant()
+        return NULL
 
     def parent(self) -> Optional["QualityErrorTreeItem"]:
         return self._item_parent
@@ -366,10 +367,10 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
         return parent_item.column_count()
 
     def data(
-        self, index: QModelIndex, role: Qt.ItemDataRole = Qt.DisplayRole
+        self, index: QModelIndex, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
     ) -> QVariant:
         if not index.isValid():
-            return QVariant()
+            return NULL
 
         item: QualityErrorTreeItem = index.internalPointer()
 
@@ -379,9 +380,12 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
         self,
         section: int,
         orientation: Qt.Orientation,
-        role: Qt.ItemDataRole = Qt.DisplayRole,
+        role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole,
     ) -> QVariant:
-        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+        if (
+            orientation == Qt.Orientation.Horizontal
+            and role == Qt.ItemDataRole.DisplayRole
+        ):
             try:
                 model_column = ModelColumn(section)
                 if model_column == ModelColumn.TYPE_OR_ID:
@@ -392,16 +396,16 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
                     )
                 return COLUMN_HEADERS[model_column]()
             except ValueError:
-                return QVariant()
-        return QVariant()
+                return NULL
+        return NULL
 
     def setData(  # noqa: N802 (qt override)
         self,
         index: QModelIndex,
         value: Any,  # noqa: ANN401
-        role: Qt.ItemDataRole = Qt.EditRole,
+        role: Qt.ItemDataRole = Qt.ItemDataRole.EditRole,
     ) -> bool:
-        if not index.isValid() or role == Qt.EditRole:
+        if not index.isValid() or role == Qt.ItemDataRole.EditRole:
             return False
 
         column = ModelColumn(index.column())
@@ -413,8 +417,8 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
         ):
             quality_error = cast(QualityError, item._item_data[0])
 
-            if role == Qt.CheckStateRole:
-                checked = value == Qt.Checked
+            if role == Qt.ItemDataRole.CheckStateRole:
+                checked = value == Qt.CheckState.Checked
                 quality_error.is_user_processed = checked
 
                 self.error_checked.emit(quality_error.unique_identifier, checked)
@@ -433,7 +437,7 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
         index: QModelIndex,
     ) -> Qt.ItemFlags:
         if not index.isValid():
-            return Qt.NoItemFlags
+            return Qt.ItemFlag.NoItemFlags
 
         column = ModelColumn(index.column())
         item: QualityErrorTreeItem = index.internalPointer()
@@ -442,7 +446,7 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
             column == ModelColumn.TYPE_OR_ID
             and item.item_type == QualityErrorTreeItemType.ERROR
         ):
-            return super().flags(index) | Qt.ItemIsUserCheckable
+            return super().flags(index) | Qt.ItemFlag.ItemIsUserCheckable
 
         return super().flags(index)
 
@@ -456,7 +460,7 @@ class QualityErrorsTreeBaseModel(QAbstractItemModel):
             for index in _get_quality_errors_indexes(
                 self, self.index(i, 0, QModelIndex())
             ):
-                _, item_data = index.data(Qt.UserRole)
+                _, item_data = index.data(Qt.ItemDataRole.UserRole)
                 current_quality_error_ids.add(
                     cast(QualityError, item_data).unique_identifier
                 )
@@ -607,10 +611,10 @@ class StyleProxyModel(QIdentityProxyModel):
         super().__init__(parent)
 
     def data(
-        self, index: QModelIndex, role: Qt.ItemDataRole = Qt.DisplayRole
+        self, index: QModelIndex, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
     ) -> QVariant:
         source_index = self.mapToSource(index)
-        data = self.sourceModel().data(source_index, Qt.UserRole)
+        data = self.sourceModel().data(source_index, Qt.ItemDataRole.UserRole)
 
         if not QVariant(data).isValid():
             return self.sourceModel().data(source_index, role)
@@ -618,7 +622,7 @@ class StyleProxyModel(QIdentityProxyModel):
         (item_type, item_data) = cast(ErrorDataType, data)
         column = ModelColumn(index.column())
         if (
-            role == Qt.FontRole
+            role == Qt.ItemDataRole.FontRole
             and column == ModelColumn.TYPE_OR_ID
             and item_type == QualityErrorTreeItemType.PRIORITY
         ):
@@ -628,7 +632,7 @@ class StyleProxyModel(QIdentityProxyModel):
             return QVariant(font)
 
         if (
-            role == Qt.FontRole
+            role == Qt.ItemDataRole.FontRole
             and column == ModelColumn.TYPE_OR_ID
             and item_type == QualityErrorTreeItemType.FEATURE_TYPE
         ):
@@ -637,15 +641,15 @@ class StyleProxyModel(QIdentityProxyModel):
             return QVariant(font)
 
         if (
-            role == Qt.ForegroundRole
+            role == Qt.ItemDataRole.ForegroundRole
             and column == ModelColumn.TYPE_OR_ID
             and item_type == QualityErrorTreeItemType.ERROR
             and cast(QualityError, item_data).is_user_processed is True
         ):
-            return QVariant(QColor(Qt.lightGray))
+            return QVariant(QColor(Qt.GlobalColor.lightGray))
 
         if (
-            role == Qt.ForegroundRole
+            role == Qt.ItemDataRole.ForegroundRole
             and column == ModelColumn.TYPE_OR_ID
             and item_type == QualityErrorTreeItemType.FEATURE
         ):
@@ -661,7 +665,7 @@ class AbstractFilterProxyModel(QSortFilterProxyModel):
 
     def __init__(self, parent: Optional[QObject] = None) -> None:
         super().__init__(parent)
-        self.setFilterRole(Qt.UserRole)
+        self.setFilterRole(Qt.ItemDataRole.UserRole)
 
     def invalidateFilter(self) -> None:  # noqa: N802 (qt override)
         super().invalidateFilter()
@@ -733,9 +737,12 @@ class FilterProxyModel(AbstractFilterProxyModel):
         self,
         section: int,
         orientation: Qt.Orientation,
-        role: Qt.ItemDataRole = Qt.DisplayRole,
+        role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole,
     ) -> QVariant:
-        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+        if (
+            orientation == Qt.Orientation.Horizontal
+            and role == Qt.ItemDataRole.DisplayRole
+        ):
             try:
                 model_column = ModelColumn(section)
                 if model_column == ModelColumn.TYPE_OR_ID:
@@ -754,8 +761,8 @@ class FilterProxyModel(AbstractFilterProxyModel):
                     )
                 return COLUMN_HEADERS[model_column]()
             except ValueError:
-                return QVariant()
-        return QVariant()
+                return NULL
+        return NULL
 
 
 class FilterByExtentProxyModel(AbstractFilterProxyModel):
@@ -799,9 +806,12 @@ class FilterByExtentProxyModel(AbstractFilterProxyModel):
         self,
         section: int,
         orientation: Qt.Orientation,
-        role: Qt.ItemDataRole = Qt.DisplayRole,
+        role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole,
     ) -> QVariant:
-        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+        if (
+            orientation == Qt.Orientation.Horizontal
+            and role == Qt.ItemDataRole.DisplayRole
+        ):
             try:
                 model_column = ModelColumn(section)
                 if model_column == ModelColumn.TYPE_OR_ID:
@@ -820,8 +830,8 @@ class FilterByExtentProxyModel(AbstractFilterProxyModel):
                     )
                 return COLUMN_HEADERS[model_column]()
             except ValueError:
-                return QVariant()
-        return QVariant()
+                return NULL
+        return NULL
 
 
 class FilterByShowUserProcessedProxyModel(AbstractFilterProxyModel):
@@ -849,9 +859,12 @@ class FilterByShowUserProcessedProxyModel(AbstractFilterProxyModel):
         self,
         section: int,
         orientation: Qt.Orientation,
-        role: Qt.ItemDataRole = Qt.DisplayRole,
+        role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole,
     ) -> QVariant:
-        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+        if (
+            orientation == Qt.Orientation.Horizontal
+            and role == Qt.ItemDataRole.DisplayRole
+        ):
             try:
                 model_column = ModelColumn(section)
                 if model_column == ModelColumn.TYPE_OR_ID:
@@ -870,5 +883,5 @@ class FilterByShowUserProcessedProxyModel(AbstractFilterProxyModel):
                     )
                 return COLUMN_HEADERS[model_column]()
             except ValueError:
-                return QVariant()
-        return QVariant()
+                return NULL
+        return NULL

--- a/src/quality_result_gui/quality_layer.py
+++ b/src/quality_result_gui/quality_layer.py
@@ -189,7 +189,7 @@ class QualityErrorLayer:
 
         symbol = self.style.create_error_symbol(quality_error)
 
-        if geom_type == QgsWkbTypes.PointGeometry:
+        if geom_type == QgsWkbTypes.GeometryType.PointGeometry:
             points = []
             if geometry.isMultipart() is False:
                 point = QgsPoint()
@@ -208,7 +208,7 @@ class QualityErrorLayer:
                 )
                 annotations.append(annotation)
 
-        elif geom_type == QgsWkbTypes.PolygonGeometry:
+        elif geom_type == QgsWkbTypes.GeometryType.PolygonGeometry:
             polygons = []
 
             if geometry.isMultipart() is False:
@@ -228,7 +228,7 @@ class QualityErrorLayer:
                 )
                 annotations.append(annotation)
 
-        elif geom_type == QgsWkbTypes.LineGeometry:
+        elif geom_type == QgsWkbTypes.GeometryType.LineGeometry:
             lines = []
             if geometry.isMultipart() is False:
                 line = QgsLineString()

--- a/src/quality_result_gui/style/quality_layer_error_symbol.py
+++ b/src/quality_result_gui/style/quality_layer_error_symbol.py
@@ -47,11 +47,11 @@ class ErrorSymbol(BaseSymbol, ABC):
     def to_qgs_symbol(
         self, geometry_type: QgsWkbTypes.GeometryType, highlighted: bool = False
     ) -> QgsSymbol:
-        if geometry_type == QgsWkbTypes.PolygonGeometry:
+        if geometry_type == QgsWkbTypes.GeometryType.PolygonGeometry:
             return self._get_polygon_symbol(highlighted)
-        if geometry_type == QgsWkbTypes.LineGeometry:
+        if geometry_type == QgsWkbTypes.GeometryType.LineGeometry:
             return self._get_line_symbol(highlighted)
-        if geometry_type == QgsWkbTypes.PointGeometry:
+        if geometry_type == QgsWkbTypes.GeometryType.PointGeometry:
             return self._get_point_symbol(highlighted)
         raise NotImplementedError()
 

--- a/src/quality_result_gui/ui/quality_error_tree_view.py
+++ b/src/quality_result_gui/ui/quality_error_tree_view.py
@@ -169,7 +169,7 @@ class QualityErrorTreeView(QTreeView):
         self,
         row_index: QModelIndex,
     ) -> Optional[QualityError]:
-        data = row_index.data(Qt.UserRole)
+        data = row_index.data(Qt.ItemDataRole.UserRole)
 
         if not QVariant(data).isValid():
             return None

--- a/src/quality_result_gui/utils/qt_utils.py
+++ b/src/quality_result_gui/utils/qt_utils.py
@@ -1,0 +1,11 @@
+from qgis.PyQt.QtCore import QT_VERSION, QVariant
+
+"""
+Unfortunately https://github.com/qgis/QGIS/blob/master/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
+tries to replace all QVariant() with NULL (QVariant(int)),
+which breaks some functionality with models.
+
+This workaround is here to provide working solution for now.
+"""
+# TODO: remove after QGIS>4 and just use None or `from qgis.core import NULL` instead
+NULL = None if QT_VERSION >= 0x060000 else QVariant()  # noqa: PLR2004

--- a/src/quality_result_gui_plugin/metadata.txt
+++ b/src/quality_result_gui_plugin/metadata.txt
@@ -28,3 +28,4 @@ experimental=True
 
 # deprecated flag (applies to the whole plugin, not just a single version)
 deprecated=False
+supportsQt6=True

--- a/src/quality_result_gui_plugin/plugin.py
+++ b/src/quality_result_gui_plugin/plugin.py
@@ -127,7 +127,7 @@ class QualityResultGuiPlugin:
 
     def _on_open_dev_tools_called(self) -> None:
         dialog = DevToolsDialog(iface.mainWindow())
-        if dialog.exec_():
+        if dialog.exec():
             self._test_json_file_path = (
                 dialog.quality_errors_data_file_widget.filePath()
             )

--- a/test/integration/test_checkbox_actions.py
+++ b/test/integration/test_checkbox_actions.py
@@ -166,8 +166,8 @@ def test_filter_with_user_processed_check_box_and_map_extent_check_box(
     # Mark first fatal error as processed -> should be filtered out
     model.setData(
         model.index(0, 0, QModelIndex()).child(0, 0).child(0, 0).child(0, 0),
-        Qt.Checked,
-        Qt.CheckStateRole,
+        Qt.CheckState.Checked,
+        Qt.ItemDataRole.CheckStateRole,
     )
     assert _count_num_fatal_rows(model) == 1
     assert _count_num_warning_rows(model) == 1

--- a/test/integration/test_tree_view.py
+++ b/test/integration/test_tree_view.py
@@ -136,8 +136,8 @@ def test_quality_error_tree_view_updates_view_partially_when_data_is_refreshed(
 @pytest.mark.parametrize(
     ("mouse_button", "should_preserve_scale"),
     [
-        (Qt.LeftButton, False),
-        (Qt.RightButton, True),
+        (Qt.MouseButton.LeftButton, False),
+        (Qt.MouseButton.RightButton, True),
     ],
     ids=[
         "with-left",

--- a/test/unit/quality_result_gui/test_quality_errors_manager.py
+++ b/test/unit/quality_result_gui/test_quality_errors_manager.py
@@ -169,9 +169,21 @@ def test_close_and_reopen_preserves_error_visibility_on_map(
         "callback_called",
     ),
     [
-        (-1, Qt.EditRole, Qt.Unchecked, None, False),
-        (Qt.Checked, Qt.CheckStateRole, Qt.Checked, True, True),
-        (Qt.Unchecked, Qt.CheckStateRole, Qt.Unchecked, False, True),
+        (-1, Qt.ItemDataRole.EditRole, Qt.CheckState.Unchecked, None, False),
+        (
+            Qt.CheckState.Checked,
+            Qt.ItemDataRole.CheckStateRole,
+            Qt.CheckState.Checked,
+            True,
+            True,
+        ),
+        (
+            Qt.CheckState.Unchecked,
+            Qt.ItemDataRole.CheckStateRole,
+            Qt.CheckState.Unchecked,
+            False,
+            True,
+        ),
     ],
 )
 def test_model_set_data_user_processed(
@@ -191,7 +203,7 @@ def test_model_set_data_user_processed(
     )
 
     model.setData(first_error_row_index, value, role)
-    check_state = model.data(first_error_row_index, Qt.CheckStateRole)
+    check_state = model.data(first_error_row_index, Qt.ItemDataRole.CheckStateRole)
     assert check_state == expected_check_state
 
     if callback_called:

--- a/test/unit/quality_result_gui/test_quality_errors_tree_model.py
+++ b/test/unit/quality_result_gui/test_quality_errors_tree_model.py
@@ -305,15 +305,17 @@ def test_model_header_data(model: FilterByExtentProxyModel):
     base_model = QualityErrorsTreeBaseModel(None)
     model.setSourceModel(base_model)
 
-    assert not QVariant(model.headerData(0, Qt.Vertical)).isValid()
-    assert QVariant(model.headerData(0, Qt.Horizontal)).isValid()
+    assert not QVariant(model.headerData(0, Qt.Orientation.Vertical)).isValid()
+    assert QVariant(model.headerData(0, Qt.Orientation.Horizontal)).isValid()
 
     for valid_col_index in [0, 1]:
-        assert QVariant(model.headerData(valid_col_index, Qt.Horizontal)).isValid()
+        assert QVariant(
+            model.headerData(valid_col_index, Qt.Orientation.Horizontal)
+        ).isValid()
 
     for invalid_col_index in [-1, 2, 3, 4, 5, 10, 99]:
         assert not QVariant(
-            model.headerData(invalid_col_index, Qt.Horizontal)
+            model.headerData(invalid_col_index, Qt.Orientation.Horizontal)
         ).isValid()
 
 
@@ -328,16 +330,16 @@ def test_total_number_of_errors_is_shown_in_header(
         *_,
     ) = filter_proxy_model_and_filters
 
-    assert "5/5" in model.headerData(0, Qt.Horizontal).value()
+    assert "5/5" in model.headerData(0, Qt.Orientation.Horizontal).value()
 
     error_type_filter._remove_filter_item(QualityErrorType.GEOMETRY)
 
-    assert "4/5" in model.headerData(0, Qt.Horizontal).value()
+    assert "4/5" in model.headerData(0, Qt.Orientation.Horizontal).value()
 
     error_type_filter._refresh_error_type_filters(ERROR_TYPE_LABEL)
     feature_type_filter._remove_filter_item("building_part_area")
 
-    assert "1/5" in model.headerData(0, Qt.Horizontal).value()
+    assert "1/5" in model.headerData(0, Qt.Orientation.Horizontal).value()
 
 
 def test_model_data_invalid_index(model: FilterByExtentProxyModel):
@@ -400,7 +402,7 @@ def test_model_data_error(
     )
     extra_info = model.data(
         _priority_1_feature_type_1_feature_1_error_1_description_index(model),
-        Qt.ToolTipRole,
+        Qt.ItemDataRole.ToolTipRole,
     )
     assert "Invalid geometry" in extra_info
     assert "Extra info" in extra_info
@@ -420,42 +422,51 @@ def test_model_data_error(
 def test_model_data_user_processed_values(model: FilterByExtentProxyModel):
     assert (
         model.data(
-            _priority_1_feature_type_1_feature_1_error_1_index(model), Qt.CheckStateRole
+            _priority_1_feature_type_1_feature_1_error_1_index(model),
+            Qt.ItemDataRole.CheckStateRole,
         )
-        == Qt.Unchecked
+        == Qt.CheckState.Unchecked
     )
     assert (
         model.data(
-            _priority_1_feature_type_1_feature_1_error_2_index(model), Qt.CheckStateRole
+            _priority_1_feature_type_1_feature_1_error_2_index(model),
+            Qt.ItemDataRole.CheckStateRole,
         )
-        == Qt.Checked
+        == Qt.CheckState.Checked
     )
 
 
 def test_model_data_error_text_color(model: FilterByExtentProxyModel):
     assert (
         model.data(
-            _priority_1_feature_type_1_feature_1_error_1_index(model), Qt.ForegroundRole
+            _priority_1_feature_type_1_feature_1_error_1_index(model),
+            Qt.ItemDataRole.ForegroundRole,
         )
         is None
     )
     assert (
         model.data(
-            _priority_1_feature_type_1_feature_1_error_2_index(model), Qt.ForegroundRole
+            _priority_1_feature_type_1_feature_1_error_2_index(model),
+            Qt.ItemDataRole.ForegroundRole,
         )
-        == Qt.lightGray
+        == Qt.GlobalColor.lightGray
     )
 
 
 def test_model_checkable_flags(model: FilterByExtentProxyModel):
     invalid_index_flags = model.flags(QModelIndex())
-    assert int(invalid_index_flags) == Qt.NoItemFlags
+    assert int(invalid_index_flags) == Qt.ItemFlag.NoItemFlags
 
     error_flags = model.flags(_priority_1_feature_type_1_feature_1_error_1_index(model))
-    assert int(error_flags & Qt.ItemIsUserCheckable) == Qt.ItemIsUserCheckable
+    assert (
+        int(error_flags & Qt.ItemFlag.ItemIsUserCheckable)
+        == Qt.ItemFlag.ItemIsUserCheckable
+    )
 
     priority_flags = model.flags(_priority_1_index(model))
-    assert int(priority_flags & Qt.ItemIsUserCheckable) == Qt.NoItemFlags
+    assert (
+        int(priority_flags & Qt.ItemFlag.ItemIsUserCheckable) == Qt.ItemFlag.NoItemFlags
+    )
 
 
 @pytest.mark.parametrize(
@@ -700,8 +711,8 @@ def test_no_rows_visible_when_all_user_processed(
 
     model.setData(
         _priority_1_feature_type_1_feature_1_error_1_index(model),
-        Qt.Checked,
-        Qt.CheckStateRole,
+        Qt.CheckState.Checked,
+        Qt.ItemDataRole.CheckStateRole,
     )
     model.set_show_processed_errors(False)
 


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

This PR uses official [QGIS migration instructions ](https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6)to add QT6 and QGIS>=4.0 support while being still backwards compatible with QT5 and QGIS 3.x versions.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [ ] Non-breaking change
- [ ] Breaking change 

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/quality-result-gui/blob/main/CHANGELOG.md
